### PR TITLE
Fix dynamic section header font

### DIFF
--- a/src/components/DynamicPersonProfileSection.tsx
+++ b/src/components/DynamicPersonProfileSection.tsx
@@ -37,7 +37,7 @@ const DynamicPersonProfileSection: React.FC<DynamicPersonProfileSectionProps> = 
           isTimTeuscher ? '' : 'lg:grid-flow-col-dense'
         }`}>
           <div className={`space-y-6 ${isTimTeuscher ? 'order-1' : 'order-2 lg:order-1'}`}>
-            <h2 className="text-4xl lg:text-5xl font-bold text-foreground">
+            <h2 className="text-4xl lg:text-5xl font-bold text-foreground font-cooper">
               {section.title}
             </h2>
             {section.subtitle && (

--- a/src/components/DynamicSocialLinksSection.tsx
+++ b/src/components/DynamicSocialLinksSection.tsx
@@ -23,7 +23,7 @@ const DynamicSocialLinksSection: React.FC<DynamicSocialLinksSectionProps> = ({ s
       <div className="container mx-auto px-4">
         <div className="text-center space-y-12">
           <div className="space-y-4">
-            <h2 className="text-4xl lg:text-5xl font-bold text-foreground">
+            <h2 className="text-4xl lg:text-5xl font-bold text-foreground font-cooper">
               {section.title}
             </h2>
             <p className="text-lg text-muted-foreground max-w-2xl mx-auto">

--- a/src/components/DynamicWTFSection.tsx
+++ b/src/components/DynamicWTFSection.tsx
@@ -15,9 +15,9 @@ const DynamicWTFSection: React.FC<DynamicWTFSectionProps> = ({ section }) => {
       <div className="container mx-auto px-4">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
           <div className="space-y-6">
-            <h2 className="text-4xl lg:text-5xl font-bold text-foreground">
-              {section.title}
-            </h2>
+          <h2 className="text-4xl lg:text-5xl font-bold text-foreground font-cooper">
+            {section.title}
+          </h2>
             <p className="text-lg text-muted-foreground leading-relaxed">
               {section.description}
             </p>


### PR DESCRIPTION
## Summary
- use `font-cooper` for dynamic section headings so they match the main style

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6881c35624808328ae81d7d72b4e5b0a