### PR TITLE
Display season and episode validation errors

### DIFF
--- a/src/pages/NewEpisode.tsx
+++ b/src/pages/NewEpisode.tsx
@@ -346,8 +346,9 @@ const NewEpisode = () => {
                     type="number"
                     min="1"
                     value={season}
-                    onChange={(e) => setSeason(parseInt(e.target.value))}
+                    onChange={(e) => setSeason(Number(e.target.value) || 1)}
                   />
+                  <FormFieldError error={validationErrors.season} />
                 </div>
                 <div>
                   <label htmlFor="episodeNumber" className="block text-sm font-medium mb-1">
@@ -358,8 +359,9 @@ const NewEpisode = () => {
                     type="number"
                     min="1"
                     value={episodeNumber}
-                    onChange={(e) => setEpisodeNumber(parseInt(e.target.value))}
+                    onChange={(e) => setEpisodeNumber(Number(e.target.value) || 1)}
                   />
+                  <FormFieldError error={validationErrors['episode_number']} />
                 </div>
               </div>
               <div>


### PR DESCRIPTION
## Summary
- ensure validation errors from `episodeSchema` show for Season and Episode number inputs
- prevent NaN values when editing Season or Episode number

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688cba5f6e208328b8971d5f123d69a7